### PR TITLE
Initial pre-flight review

### DIFF
--- a/Sources/asbmutil/APIClient.swift
+++ b/Sources/asbmutil/APIClient.swift
@@ -501,7 +501,7 @@ actor APIClient {
         let claims: [String: Any] = [
             "iss": c.clientId,
             "sub": c.clientId,
-            "aud": "https://account.apple.com/auth/oauth2/v2/token",
+            "aud": "https://account.apple.com/auth/oauth2/token",
             "iat": now,
             "exp": now + 1_200,
             "jti": UUID().uuidString

--- a/Sources/asbmutil/Commands.swift
+++ b/Sources/asbmutil/Commands.swift
@@ -80,7 +80,10 @@ struct Assign: AsyncParsableCommand {
         
         let serialNumbers: [String]
         if let serials = serials {
-            serialNumbers = serials.split(separator: ",").map(String.init)
+            serialNumbers = serials
+                .split(separator: ",")
+                .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
         } else if let csvFile = csvFile {
             serialNumbers = try readSerialsFromCSV(filePath: csvFile)
         } else {
@@ -125,7 +128,10 @@ struct Unassign: AsyncParsableCommand {
         
         let serialNumbers: [String]
         if let serials = serials {
-            serialNumbers = serials.split(separator: ",").map(String.init)
+            serialNumbers = serials
+                .split(separator: ",")
+                .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
         } else if let csvFile = csvFile {
             serialNumbers = try readSerialsFromCSV(filePath: csvFile)
         } else {


### PR DESCRIPTION
## Summary
This PR fixes two runtime issues discovered during fresh-clone preflight review:

1. Aligns JWT `aud` claim with the OAuth token endpoint used by the client.
2. Normalizes `--serials` parsing for `assign` and `unassign` by trimming whitespace and dropping empty entries.

## Changes
- Updated JWT audience claim:
  - `/Users/danksnelson/Documents/GitHub/dan-snelson/asbmutil/Sources/asbmutil/APIClient.swift:504`
  - `aud` now uses `https://account.apple.com/auth/oauth2/token` (matches token request URL).

- Updated serial parsing for assignment commands:
  - `/Users/danksnelson/Documents/GitHub/dan-snelson/asbmutil/Sources/asbmutil/Commands.swift:83`
  - `/Users/danksnelson/Documents/GitHub/dan-snelson/asbmutil/Sources/asbmutil/Commands.swift:128`
  - Parsing now:
    - splits on comma,
    - trims whitespace/newlines,
    - filters empty values.

## Why
- The previous `aud` value (`.../oauth2/v2/token`) did not match the actual token endpoint (`.../oauth2/token`), which can cause auth failures if audience is strictly validated.
- `--serials` previously accepted raw split values, so input like `"ABC123, DEF456"` could pass `" DEF456"` and fail downstream.

## Impact
- No interface changes.
- Safer, more forgiving CLI input handling.
- Lower risk of token-exchange failure due to audience mismatch.

## Verification
- `swift build -c release` completes successfully after these changes.

## Suggested Test Notes
1. Build
- Run: `swift build -c release`
- Expected: successful release build.

2. Serial normalization (`assign`)
- Run:
  - `./.build/release/asbmutil assign --serials "ABC123, DEF456 , ,GHI789" --mdm "YourMDM" --profile "your-profile"`
- Expected:
  - Parsed serials are effectively `["ABC123", "DEF456", "GHI789"]`.
  - No leading/trailing space artifacts in submitted serials.

3. Serial normalization (`unassign`)
- Run:
  - `./.build/release/asbmutil unassign --serials "ABC123, DEF456 , ,GHI789" --mdm "YourMDM" --profile "your-profile"`
- Expected:
  - Same normalization behavior as `assign`.

4. Regression checks for existing valid input
- Run with no spaces:
  - `--serials "ABC123,DEF456"`
- Expected:
  - Behavior unchanged from previous versions.

5. OAuth audience alignment smoke test
- Run any API command requiring token minting (with valid credentials), e.g.:
  - `./.build/release/asbmutil list-mdm-servers --profile "your-profile"`
- Expected:
  - Token exchange succeeds and command proceeds without auth audience-related failure.