### PR TITLE
Trim and validate credential identifiers on save and load

### DIFF
--- a/Sources/app/ViewModels/SettingsViewModel.swift
+++ b/Sources/app/ViewModels/SettingsViewModel.swift
@@ -55,7 +55,17 @@ final class SettingsViewModel {
         isSaving = true
         saveStatus = nil
 
-        let blob = KCBlob(clientId: clientId, keyId: keyId, privateKey: pemContent, teamId: "")
+        let cleanClientId = clientId.sanitizedIdentifier
+        let cleanKeyId = keyId.sanitizedIdentifier
+        if cleanClientId.contains(where: { $0.isNewline }) || cleanKeyId.contains(where: { $0.isNewline }) {
+            saveStatus = .error("Client ID and Key ID must be single-line values")
+            isSaving = false
+            return
+        }
+        clientId = cleanClientId
+        keyId = cleanKeyId
+
+        let blob = KCBlob(clientId: cleanClientId, keyId: cleanKeyId, privateKey: pemContent, teamId: "")
         let status = Keychain.saveBlob(blob, profileName: selectedProfileName)
 
         if status == 0 {

--- a/Sources/app/Views/Settings/SettingsView.swift
+++ b/Sources/app/Views/Settings/SettingsView.swift
@@ -152,7 +152,15 @@ struct SettingsView: View {
                     .keyboardShortcut(.cancelAction)
                 Spacer()
                 Button("Create") {
-                    let blob = KCBlob(clientId: newClientId, keyId: newKeyId, privateKey: newPem, teamId: "")
+                    let cleanClientId = newClientId.sanitizedIdentifier
+                    let cleanKeyId = newKeyId.sanitizedIdentifier
+                    guard !cleanClientId.contains(where: { $0.isNewline }),
+                          !cleanKeyId.contains(where: { $0.isNewline }) else {
+                        return
+                    }
+                    newClientId = cleanClientId
+                    newKeyId = cleanKeyId
+                    let blob = KCBlob(clientId: cleanClientId, keyId: cleanKeyId, privateKey: newPem, teamId: "")
                     Keychain.saveBlob(blob, profileName: newName)
                     viewModel.loadProfiles()
                     appViewModel.loadProfiles()

--- a/Sources/app/Views/Settings/SettingsView.swift
+++ b/Sources/app/Views/Settings/SettingsView.swift
@@ -83,6 +83,7 @@ struct SettingsView: View {
     @State private var newKeyId = ""
     @State private var newPem = ""
     @State private var showNewPemPicker = false
+    @State private var newProfileError: String?
 
     private var profilesTab: some View {
         Form {
@@ -97,6 +98,7 @@ struct SettingsView: View {
                     newClientId = ""
                     newKeyId = ""
                     newPem = ""
+                    newProfileError = nil
                 } label: {
                     Label("Add Profile", systemImage: "plus")
                 }
@@ -147,24 +149,33 @@ struct SettingsView: View {
                 }
             }
 
+            if let newProfileError {
+                Label(newProfileError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red).font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             HStack {
                 Button("Cancel") { showNewProfile = false }
                     .keyboardShortcut(.cancelAction)
                 Spacer()
                 Button("Create") {
+                    let cleanName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
                     let cleanClientId = newClientId.sanitizedIdentifier
                     let cleanKeyId = newKeyId.sanitizedIdentifier
-                    guard !cleanClientId.contains(where: { $0.isNewline }),
-                          !cleanKeyId.contains(where: { $0.isNewline }) else {
+                    if cleanClientId.contains(where: { $0.isNewline }) || cleanKeyId.contains(where: { $0.isNewline }) {
+                        newProfileError = "Client ID and Key ID must be single-line values — re-paste without line breaks."
                         return
                     }
+                    newName = cleanName
                     newClientId = cleanClientId
                     newKeyId = cleanKeyId
+                    newProfileError = nil
                     let blob = KCBlob(clientId: cleanClientId, keyId: cleanKeyId, privateKey: newPem, teamId: "")
-                    Keychain.saveBlob(blob, profileName: newName)
+                    Keychain.saveBlob(blob, profileName: cleanName)
                     viewModel.loadProfiles()
                     appViewModel.loadProfiles()
-                    expandedProfile = newName
+                    expandedProfile = cleanName
                     showNewProfile = false
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/cli/ConfigCommand.swift
+++ b/Sources/cli/ConfigCommand.swift
@@ -19,8 +19,13 @@ struct Config: ParsableCommand {
         var profileName: String = "default"
 
         func run() throws {
+            let cleanClientId = clientId.sanitizedIdentifier
+            let cleanKeyId = keyId.sanitizedIdentifier
+            if cleanClientId.contains(where: { $0.isNewline }) || cleanKeyId.contains(where: { $0.isNewline }) {
+                throw RuntimeError("--client-id and --key-id must be single-line values")
+            }
             let pem = try String(contentsOfFile: pemPath)
-            let blob = KCBlob(clientId: clientId, keyId: keyId, privateKey: pem, teamId: "")
+            let blob = KCBlob(clientId: cleanClientId, keyId: cleanKeyId, privateKey: pem, teamId: "")
             guard Keychain.saveBlob(blob, profileName: profileName) == 0 else {
                 throw RuntimeError("credential store write failed")
             }

--- a/Sources/core/Auth/Creds.swift
+++ b/Sources/core/Auth/Creds.swift
@@ -10,10 +10,12 @@ public enum Creds {
                 throw RuntimeError("missing keychain items for current profile '\(profile)' – run: asbmutil config set")
             }
         }
-        let scope = blob.clientId.hasPrefix("SCHOOLAPI") ? "school.api" : "business.api"
+        let cleanClientId = blob.clientId.sanitizedIdentifier
+        let cleanKeyId = blob.keyId.sanitizedIdentifier
+        let scope = cleanClientId.hasPrefix("SCHOOLAPI") ? "school.api" : "business.api"
         return Credentials(
-            clientId:      blob.clientId,
-            keyId:         blob.keyId,
+            clientId:      cleanClientId,
+            keyId:         cleanKeyId,
             privateKeyPEM: blob.privateKey,
             scope:         scope
         )

--- a/Sources/core/Auth/Creds.swift
+++ b/Sources/core/Auth/Creds.swift
@@ -12,6 +12,9 @@ public enum Creds {
         }
         let cleanClientId = blob.clientId.sanitizedIdentifier
         let cleanKeyId = blob.keyId.sanitizedIdentifier
+        if cleanClientId.contains(where: { $0.isNewline }) || cleanKeyId.contains(where: { $0.isNewline }) {
+            throw RuntimeError("stored credentials for profile '\(profile)' contain embedded newlines (likely a paste error). Re-save them in Settings or run: asbmutil config set --profile \(profile)")
+        }
         let scope = cleanClientId.hasPrefix("SCHOOLAPI") ? "school.api" : "business.api"
         return Credentials(
             clientId:      cleanClientId,

--- a/Sources/core/Utilities/StringSanitization.swift
+++ b/Sources/core/Utilities/StringSanitization.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    /// Trim leading/trailing whitespace and newlines. Apple OAuth identifiers
+    /// (client_id, key_id) are single-line tokens; a stray newline from the
+    /// clipboard ends up in the JWT iss/sub and the URL query, which Apple
+    /// rejects as `invalid_client`.
+    public var sanitizedIdentifier: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary

A user (ASM tenant) hit `HTTP 400 invalid_client` when running `asbmutil list-mdm-servers`. The dumped `TOKEN-URL` showed the `client_id` duplicated with a URL-encoded newline:

```
client_id=SCHOOLAPI.02d7a543-...-2dc05895e4f1%0ASCHOOLAPI.02d7a543-...-2dc05895e4f1
```

Tracing the path: the SwiftUI `TextField` → `KCBlob` → `JSONEncoder` → Keychain → `JSONDecoder` → `Credentials` → `makeJWT` / token URL flow had **no trimming or validation anywhere**. A paste with trailing whitespace or a double-paste from a clipboard manager ended up in the JWT `iss`/`sub` and the OAuth token URL verbatim, which Apple rejects.

## Changes

- **`Sources/core/Utilities/StringSanitization.swift`** (new) — `String.sanitizedIdentifier` extension that trims whitespace + newlines.
- **`SettingsViewModel.saveCredentials()`** — trims client/key IDs, rejects internal newlines, surfaces the error in the UI.
- **`SettingsView.swift` new-profile sheet's Create button** — same trim + guard.
- **`ConfigCommand.Set.run()`** — same trim + guard for `--client-id` / `--key-id` CLI flags.
- **`Creds.load()`** — self-heals: trims on read so existing corrupted profiles work without manual cleanup, and Apple sees a clean identifier in the JWT/URL.

## Test plan

- [ ] Save a profile with a trailing newline in the Client ID field; confirm it's stored trimmed and `list-mdm-servers` succeeds.
- [ ] Save a profile with an embedded newline (paste two copies of the value); confirm the GUI shows "Client ID and Key ID must be single-line values" and the bad value isn't written.
- [ ] CLI: `asbmutil config set --client-id $'SCHOOLAPI.xxx\n' --key-id ... --pem-path ...`; confirm trimmed.
- [ ] Existing profile with an already-corrupted Client ID: `asbmutil list-mdm-servers` succeeds without re-saving (Creds.load self-heal).
- [ ] `swift build` clean.