### PR TITLE
Add --resume flag to list-devices for restartable large pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,15 +639,15 @@ asbmutil list-devices --resume --devices-per-page 500 > devices.json
 
 With `--resume`:
 
-* After each successful page, the current cursor plus the accumulated device list are written to `~/.config/asbmutil/state/<profile>-list-devices.json`.
-* If the run fails partway, simply re-run the same command. The next invocation reads the state file, starts from the saved cursor, and appends to the in-memory collection until the pull completes.
-* On successful completion, the state file is removed so the next fresh `--resume` run starts clean.
+* After each successful page, a small checkpoint (cursor + counts) is written to `~/.config/asbmutil/state/<profile>-list-devices.json` and that page's devices are appended to a sibling `<profile>-list-devices.jsonl` spool. Both files are mode `0600` under a `0700` directory.
+* If the run fails partway, simply re-run the same command. The next invocation reads the checkpoint, replays devices from the spool, starts from the saved cursor, and continues until the pull completes.
+* On successful completion of the whole command — including any post-listing steps like AppleCare enrichment — both files are removed so the next fresh `--resume` run starts clean.
 
 Tips for very large fleets:
 
 * Reduce `--devices-per-page` (try `500` or `250`) — smaller pages return faster and are less likely to hit the per-request timeout.
 * Combine with `--show-pagination` to see live progress on stderr.
-* `--include-applecare` runs after the device list is complete, so it doesn't participate in resume; if you need both, do the resumable pull first, then enrich the resulting JSON in a second step.
+* `--include-applecare` can be combined with `--resume`: resume covers the device-listing stage, AppleCare enrichment then runs on the completed list, and the state files are only cleared once enrichment and output finish successfully.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For organizations managing multiple ABM instances, you can create named profiles
 ./asbmutil list-devices --include-applecare                            # Enrich every device with AppleCare coverage (4 parallel)
 ./asbmutil list-devices --include-applecare --applecare-concurrency 2  # Lower concurrency for flakier networks
 ./asbmutil list-devices --include-applecare --no-applecare-retry       # Skip the sequential second-pass retry
+./asbmutil list-devices --resume                                       # Resumable pull for large fleets; survives mid-run failures
 
 # Device Operations (using specific profile)
 ./asbmutil list-devices --profile "school-district-2"
@@ -627,6 +628,26 @@ export NO_PROXY=*.internal.example,localhost
 `HTTPS_PROXY` is preferred (all API traffic is HTTPS); `HTTP_PROXY` is honored as a fallback. `NO_PROXY` is matched against the auth host (`account.apple.com`) and the scope-specific API host (`api-business.apple.com` or `api-school.apple.com`); if every host is bypassed, the env-var proxy is skipped and the system proxy applies. Lowercase variants (`https_proxy`, etc.) work too.
 
 Proxies that require authentication should rely on system credentials (Negotiate/Kerberos via macOS); embedded `user:pass@` in the proxy URL is not currently extracted.
+
+## Resuming large device pulls
+
+For organizations with tens of thousands of devices in ABM/ASM, a full `list-devices` pull can run long enough to hit a transient timeout or network blip. Pass `--resume` to make the pull restartable:
+
+```bash
+asbmutil list-devices --resume --devices-per-page 500 > devices.json
+```
+
+With `--resume`:
+
+* After each successful page, the current cursor plus the accumulated device list are written to `~/.config/asbmutil/state/<profile>-list-devices.json`.
+* If the run fails partway, simply re-run the same command. The next invocation reads the state file, starts from the saved cursor, and appends to the in-memory collection until the pull completes.
+* On successful completion, the state file is removed so the next fresh `--resume` run starts clean.
+
+Tips for very large fleets:
+
+* Reduce `--devices-per-page` (try `500` or `250`) — smaller pages return faster and are less likely to hit the per-request timeout.
+* Combine with `--show-pagination` to see live progress on stderr.
+* `--include-applecare` runs after the device list is complete, so it doesn't participate in resume; if you need both, do the resumable pull first, then enrich the resulting JSON in a second step.
 
 ## Requirements
 

--- a/Sources/cli/Commands.swift
+++ b/Sources/cli/Commands.swift
@@ -26,6 +26,9 @@ struct ListDevices: AsyncParsableCommand {
     @Flag(name: .customLong("no-applecare-retry"), help: "Skip the sequential second-pass retry for AppleCare lookups that fail the parallel pass")
     var noAppleCareRetry: Bool = false
 
+    @Flag(name: .customLong("resume"), help: "Persist progress after each page and pick up from a saved cursor on subsequent runs. State is cleared on successful completion.")
+    var resume: Bool = false
+
     @Option(name: .customLong("profile"), help: "Profile name to use for credentials")
     var profileName: String?
 
@@ -59,7 +62,52 @@ struct ListDevices: AsyncParsableCommand {
             }
         }
 
-        let devices = try await client.listDevices(devicesPerPage: devicesPerPage, totalLimit: totalLimit, showPagination: showPagination)
+        let resolvedProfile = profileName ?? Keychain.getCurrentProfile()
+        let resumeHandle: APIClient.ResumeHandle?
+        let store: ResumeStore?
+        if resume {
+            let s = try ResumeStore(profile: resolvedProfile)
+            store = s
+            let prior = try s.load()
+            if let prior {
+                if let savedPerPage = prior.devicesPerPage, let nowPerPage = devicesPerPage, savedPerPage != nowPerPage {
+                    FileHandle.standardError.write(Data("Warning: resuming with devicesPerPage=\(nowPerPage) but saved state used \(savedPerPage). Apple's cursor should still work.\n".utf8))
+                }
+                FileHandle.standardError.write(Data("Resuming from \(s.path) — \(prior.devices.count) devices, \(prior.pagesCompleted) pages completed.\n".utf8))
+            } else {
+                FileHandle.standardError.write(Data("No prior progress; starting fresh and saving to \(s.path) after each page.\n".utf8))
+            }
+            let perPage = devicesPerPage
+            let limit = totalLimit
+            resumeHandle = APIClient.ResumeHandle(
+                startCursor: prior?.cursor,
+                initialDevices: prior?.devices ?? []
+            ) { cursor, devices, pagesCompleted in
+                let state = ListDevicesResumeState(
+                    profile: resolvedProfile,
+                    cursor: cursor,
+                    devices: devices,
+                    devicesPerPage: perPage,
+                    totalLimit: limit,
+                    pagesCompleted: pagesCompleted
+                )
+                try s.save(state)
+            }
+        } else {
+            store = nil
+            resumeHandle = nil
+        }
+
+        let devices = try await client.listDevices(
+            devicesPerPage: devicesPerPage,
+            totalLimit: totalLimit,
+            showPagination: showPagination,
+            resume: resumeHandle
+        )
+
+        if resume {
+            try store?.clear()
+        }
 
         let encoder = JSONEncoder()
         if includeAppleCare {

--- a/Sources/cli/Commands.swift
+++ b/Sources/cli/Commands.swift
@@ -62,36 +62,37 @@ struct ListDevices: AsyncParsableCommand {
             }
         }
 
-        let resolvedProfile = profileName ?? Keychain.getCurrentProfile()
         let resumeHandle: APIClient.ResumeHandle?
         let store: ResumeStore?
         if resume {
+            let resolvedProfile = profileName ?? Keychain.getCurrentProfile()
             let s = try ResumeStore(profile: resolvedProfile)
             store = s
             let prior = try s.load()
             if let prior {
-                if let savedPerPage = prior.devicesPerPage, let nowPerPage = devicesPerPage, savedPerPage != nowPerPage {
+                if let savedPerPage = prior.checkpoint.devicesPerPage, let nowPerPage = devicesPerPage, savedPerPage != nowPerPage {
                     FileHandle.standardError.write(Data("Warning: resuming with devicesPerPage=\(nowPerPage) but saved state used \(savedPerPage). Apple's cursor should still work.\n".utf8))
                 }
-                FileHandle.standardError.write(Data("Resuming from \(s.path) — \(prior.devices.count) devices, \(prior.pagesCompleted) pages completed.\n".utf8))
+                FileHandle.standardError.write(Data("Resuming from \(s.statePath) — \(prior.devices.count) devices, \(prior.checkpoint.pagesCompleted) pages completed.\n".utf8))
             } else {
-                FileHandle.standardError.write(Data("No prior progress; starting fresh and saving to \(s.path) after each page.\n".utf8))
+                FileHandle.standardError.write(Data("No prior progress; starting fresh and saving to \(s.statePath) after each page.\n".utf8))
             }
             let perPage = devicesPerPage
             let limit = totalLimit
             resumeHandle = APIClient.ResumeHandle(
-                startCursor: prior?.cursor,
-                initialDevices: prior?.devices ?? []
-            ) { cursor, devices, pagesCompleted in
-                let state = ListDevicesResumeState(
+                startCursor: prior?.checkpoint.cursor,
+                initialDevices: prior?.devices ?? [],
+                initialPagesCompleted: prior?.checkpoint.pagesCompleted ?? 0
+            ) { cursor, newPageDevices, totalDevices, pagesCompleted in
+                let checkpoint = ListDevicesCheckpoint(
                     profile: resolvedProfile,
                     cursor: cursor,
-                    devices: devices,
                     devicesPerPage: perPage,
                     totalLimit: limit,
-                    pagesCompleted: pagesCompleted
+                    pagesCompleted: pagesCompleted,
+                    devicesCount: totalDevices
                 )
-                try s.save(state)
+                try s.appendPage(checkpoint: checkpoint, newDevices: newPageDevices)
             }
         } else {
             store = nil
@@ -105,10 +106,6 @@ struct ListDevices: AsyncParsableCommand {
             resume: resumeHandle
         )
 
-        if resume {
-            try store?.clear()
-        }
-
         let encoder = JSONEncoder()
         if includeAppleCare {
             let enriched = await client.enrichWithAppleCare(
@@ -120,6 +117,13 @@ struct ListDevices: AsyncParsableCommand {
             print(String(decoding: try encoder.encode(enriched), as: UTF8.self))
         } else {
             print(String(decoding: try encoder.encode(devices), as: UTF8.self))
+        }
+
+        // Clear resume state only after the whole command (including AppleCare enrichment and
+        // final output) succeeds — otherwise a crash during enrichment leaves the user without
+        // the device list and without a way to resume.
+        if resume {
+            try store?.clear()
         }
     }
 }

--- a/Sources/core/API/APIClient.swift
+++ b/Sources/core/API/APIClient.swift
@@ -125,21 +125,26 @@ public actor APIClient {
 
     /// Caller-supplied hooks for resuming a partially-completed pull.
     ///
-    /// `startCursor` and `initialDevices` seed the pagination from a saved checkpoint;
-    /// `onPageComplete` runs after each successful page so the caller can persist the new cursor
-    /// and accumulated devices to a state file.
+    /// `startCursor` and `initialDevices` seed the pagination from a saved checkpoint and
+    /// `initialPagesCompleted` carries the cumulative page count forward so callbacks see a
+    /// monotonically increasing `pagesCompleted` across resumes. `onPageComplete` runs after
+    /// each successful page; it receives only the new page's devices (so the caller can append
+    /// to a spool rather than rewriting the full list) along with the running total.
     public struct ResumeHandle: Sendable {
         public let startCursor: String?
         public let initialDevices: [DeviceAttributes]
-        public let onPageComplete: @Sendable (_ cursor: String?, _ devices: [DeviceAttributes], _ pagesCompleted: Int) async throws -> Void
+        public let initialPagesCompleted: Int
+        public let onPageComplete: @Sendable (_ cursor: String?, _ newPageDevices: [DeviceAttributes], _ totalDevices: Int, _ pagesCompleted: Int) async throws -> Void
 
         public init(
             startCursor: String?,
             initialDevices: [DeviceAttributes],
-            onPageComplete: @escaping @Sendable (String?, [DeviceAttributes], Int) async throws -> Void
+            initialPagesCompleted: Int = 0,
+            onPageComplete: @escaping @Sendable (String?, [DeviceAttributes], Int, Int) async throws -> Void
         ) {
             self.startCursor = startCursor
             self.initialDevices = initialDevices
+            self.initialPagesCompleted = initialPagesCompleted
             self.onPageComplete = onPageComplete
         }
     }
@@ -152,11 +157,13 @@ public actor APIClient {
     ) async throws -> [DeviceAttributes] {
         var cursor: String? = resume?.startCursor
         var out: [DeviceAttributes] = resume?.initialDevices ?? []
-        var page = 1
-        var totalDevices = out.count
+        let initialPagesCompleted = resume?.initialPagesCompleted ?? 0
+        var pagesThisRun = 0
 
-        if let resume, !resume.initialDevices.isEmpty {
-            FileHandle.standardError.write(Data("Resuming with \(out.count) devices already collected\(cursor == nil ? " (no saved cursor — nothing left to fetch)" : "")\n".utf8))
+        // If a previous run already collected enough devices for our limit, return immediately
+        // before issuing any request — the math below would otherwise underflow.
+        if let totalLimit, out.count >= totalLimit {
+            return Array(out.prefix(totalLimit))
         }
 
         // Resume state with no cursor means the previous run finished but the state was never
@@ -168,7 +175,7 @@ public actor APIClient {
         repeat {
             let r = try await fetchOrgDevicesPage(cursor: cursor, devicesPerPage: devicesPerPage)
             let pageDeviceCount = r.data.count
-            let remainingNeeded = totalLimit.map { $0 - totalDevices }
+            let remainingNeeded = totalLimit.map { max(0, $0 - out.count) }
 
             // If we have a total limit, only take what we need
             let devicesToTake = if let remaining = remainingNeeded {
@@ -178,12 +185,16 @@ public actor APIClient {
             }
 
             let pageDevices = Array(r.data.prefix(devicesToTake))
-            totalDevices += devicesToTake
+            let newAttributes = pageDevices.map(\.attributes)
+            out += newAttributes
+            cursor = r.meta?.paging.nextCursor
+            pagesThisRun += 1
+            let cumulativePages = initialPagesCompleted + pagesThisRun
 
             if showPagination {
                 let pageSizeInfo = devicesPerPage.map { " (devices per page: \($0))" } ?? ""
                 let limitInfo = totalLimit.map { " [limit: \($0)]" } ?? ""
-                FileHandle.standardError.write(Data("Page \(page): retrieved \(devicesToTake)/\(pageDeviceCount) devices\(pageSizeInfo), total so far: \(totalDevices)\(limitInfo)\n".utf8))
+                FileHandle.standardError.write(Data("Page \(cumulativePages): retrieved \(devicesToTake)/\(pageDeviceCount) devices\(pageSizeInfo), total so far: \(out.count)\(limitInfo)\n".utf8))
 
                 if let nextCursor = r.meta?.paging.nextCursor {
                     FileHandle.standardError.write(Data("  Next cursor: \(String(nextCursor.prefix(20)))...\n".utf8))
@@ -192,17 +203,13 @@ public actor APIClient {
                 }
             } else {
                 let pageSizeInfo = devicesPerPage.map { " (devices per page: \($0))" } ?? ""
-                FileHandle.standardError.write(Data("Page \(page): found \(devicesToTake) devices\(pageSizeInfo), total so far: \(totalDevices)\n".utf8))
+                FileHandle.standardError.write(Data("Page \(cumulativePages): found \(devicesToTake) devices\(pageSizeInfo), total so far: \(out.count)\n".utf8))
             }
 
-            out += pageDevices.map(\.attributes)
-            cursor = r.meta?.paging.nextCursor
-            page += 1
-
-            try await resume?.onPageComplete(cursor, out, page - 1)
+            try await resume?.onPageComplete(cursor, newAttributes, out.count, cumulativePages)
 
             // Check if we've reached our total limit
-            if let totalLimit = totalLimit, totalDevices >= totalLimit {
+            if let totalLimit = totalLimit, out.count >= totalLimit {
                 if showPagination {
                     FileHandle.standardError.write(Data("Reached total limit of \(totalLimit) devices\n".utf8))
                 }
@@ -217,7 +224,8 @@ public actor APIClient {
 
         if showPagination {
             let limitStatus = totalLimit.map { " (limited to \($0))" } ?? ""
-            FileHandle.standardError.write(Data("Pagination complete: \(totalDevices) total devices across \(page - 1) pages\(limitStatus)\n".utf8))
+            let totalPages = initialPagesCompleted + pagesThisRun
+            FileHandle.standardError.write(Data("Pagination complete: \(out.count) total devices across \(totalPages) pages\(limitStatus)\n".utf8))
         }
         return out
     }

--- a/Sources/core/API/APIClient.swift
+++ b/Sources/core/API/APIClient.swift
@@ -123,11 +123,47 @@ public actor APIClient {
         return try await send(req)
     }
 
-    public func listDevices(devicesPerPage: Int? = nil, totalLimit: Int? = nil, showPagination: Bool = false) async throws -> [DeviceAttributes] {
-        var cursor: String? = nil
+    /// Caller-supplied hooks for resuming a partially-completed pull.
+    ///
+    /// `startCursor` and `initialDevices` seed the pagination from a saved checkpoint;
+    /// `onPageComplete` runs after each successful page so the caller can persist the new cursor
+    /// and accumulated devices to a state file.
+    public struct ResumeHandle: Sendable {
+        public let startCursor: String?
+        public let initialDevices: [DeviceAttributes]
+        public let onPageComplete: @Sendable (_ cursor: String?, _ devices: [DeviceAttributes], _ pagesCompleted: Int) async throws -> Void
+
+        public init(
+            startCursor: String?,
+            initialDevices: [DeviceAttributes],
+            onPageComplete: @escaping @Sendable (String?, [DeviceAttributes], Int) async throws -> Void
+        ) {
+            self.startCursor = startCursor
+            self.initialDevices = initialDevices
+            self.onPageComplete = onPageComplete
+        }
+    }
+
+    public func listDevices(
+        devicesPerPage: Int? = nil,
+        totalLimit: Int? = nil,
+        showPagination: Bool = false,
+        resume: ResumeHandle? = nil
+    ) async throws -> [DeviceAttributes] {
+        var cursor: String? = resume?.startCursor
+        var out: [DeviceAttributes] = resume?.initialDevices ?? []
         var page = 1
-        var totalDevices = 0
-        var out: [DeviceAttributes] = []
+        var totalDevices = out.count
+
+        if let resume, !resume.initialDevices.isEmpty {
+            FileHandle.standardError.write(Data("Resuming with \(out.count) devices already collected\(cursor == nil ? " (no saved cursor — nothing left to fetch)" : "")\n".utf8))
+        }
+
+        // Resume state with no cursor means the previous run finished but the state was never
+        // cleared. Return what we have and let the caller decide whether to clear it.
+        if cursor == nil && resume != nil && !out.isEmpty {
+            return out
+        }
 
         repeat {
             let r = try await fetchOrgDevicesPage(cursor: cursor, devicesPerPage: devicesPerPage)
@@ -162,6 +198,8 @@ public actor APIClient {
             out += pageDevices.map(\.attributes)
             cursor = r.meta?.paging.nextCursor
             page += 1
+
+            try await resume?.onPageComplete(cursor, out, page - 1)
 
             // Check if we've reached our total limit
             if let totalLimit = totalLimit, totalDevices >= totalLimit {

--- a/Sources/core/Utilities/ResumeStore.swift
+++ b/Sources/core/Utilities/ResumeStore.swift
@@ -1,81 +1,175 @@
 import Foundation
 
-/// Persistent snapshot of a paginated `list-devices` pull so a failed run can be resumed.
-public struct ListDevicesResumeState: Codable, Sendable {
+/// Checkpoint metadata for an in-progress paginated `list-devices` pull.
+///
+/// The accumulated device list is stored separately as an append-only JSONL spool so we don't
+/// rewrite a multi-megabyte JSON file after every page. `devicesCount` is the spool length we
+/// expect at this checkpoint; it's used as a sanity check on load.
+public struct ListDevicesCheckpoint: Codable, Sendable {
     public let profile: String
     public let cursor: String?
-    public let devices: [DeviceAttributes]
     public let devicesPerPage: Int?
     public let totalLimit: Int?
     public let pagesCompleted: Int
+    public let devicesCount: Int
     public let savedAt: Date
 
     public init(
         profile: String,
         cursor: String?,
-        devices: [DeviceAttributes],
         devicesPerPage: Int?,
         totalLimit: Int?,
         pagesCompleted: Int,
+        devicesCount: Int,
         savedAt: Date = Date()
     ) {
         self.profile = profile
         self.cursor = cursor
-        self.devices = devices
         self.devicesPerPage = devicesPerPage
         self.totalLimit = totalLimit
         self.pagesCompleted = pagesCompleted
+        self.devicesCount = devicesCount
         self.savedAt = savedAt
     }
 }
 
+/// What `ResumeStore.load` hands back: the checkpoint plus the devices recovered from the spool.
+public struct ListDevicesResumeState: Sendable {
+    public let checkpoint: ListDevicesCheckpoint
+    public let devices: [DeviceAttributes]
+}
+
 /// File-backed store for a single profile's `list-devices` resume state.
 ///
-/// Layout: `~/.config/asbmutil/state/<profile>-list-devices.json`. The directory is created on
-/// first write. Reads return nil when the file is missing so `--resume` on a fresh run is a no-op
-/// rather than an error.
+/// Layout, under `<config>/state/`:
+///   - `<encoded-profile>-list-devices.json`     small checkpoint (cursor + counts)
+///   - `<encoded-profile>-list-devices.jsonl`    append-only spool, one DeviceAttributes per line
+///
+/// The directory is created on first write with 0700 and files are written with 0600 so the
+/// device inventory isn't world-readable (matches the FileCredentialStore convention).
+///
+/// Profile names are percent-encoded into the filename so e.g. `a/b` and `a_b` get distinct
+/// state paths and don't collide.
 public struct ResumeStore: Sendable {
     public let profile: String
-    private let fileURL: URL
+    private let stateURL: URL
+    private let spoolURL: URL
 
     public init(profile: String) throws {
         self.profile = profile
-        self.fileURL = try Self.fileURL(for: profile)
+        let (state, spool) = try Self.fileURLs(for: profile)
+        self.stateURL = state
+        self.spoolURL = spool
     }
 
     public func load() throws -> ListDevicesResumeState? {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
-        let data = try Data(contentsOf: fileURL)
+        guard FileManager.default.fileExists(atPath: stateURL.path) else { return nil }
+        let data = try Data(contentsOf: stateURL)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(ListDevicesResumeState.self, from: data)
+        let checkpoint = try decoder.decode(ListDevicesCheckpoint.self, from: data)
+        let devices = try readSpool()
+        return ListDevicesResumeState(checkpoint: checkpoint, devices: devices)
     }
 
-    public func save(_ state: ListDevicesResumeState) throws {
-        try FileManager.default.createDirectory(
-            at: fileURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
+    /// Append a page's devices to the spool, then atomically rewrite the small checkpoint file.
+    /// Spool grows by one line per device per page; the checkpoint file stays tiny regardless of
+    /// fleet size, so per-page write cost is O(page size) rather than O(total devices).
+    public func appendPage(checkpoint: ListDevicesCheckpoint, newDevices: [DeviceAttributes]) throws {
+        try ensureDirectory()
+        if !newDevices.isEmpty {
+            try appendToSpool(newDevices)
+        }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode(state)
-        try data.write(to: fileURL, options: [.atomic])
+        let data = try encoder.encode(checkpoint)
+        try data.write(to: stateURL, options: [.atomic])
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: stateURL.path)
     }
 
     public func clear() throws {
-        if FileManager.default.fileExists(atPath: fileURL.path) {
-            try FileManager.default.removeItem(at: fileURL)
+        let fm = FileManager.default
+        if fm.fileExists(atPath: stateURL.path) { try fm.removeItem(at: stateURL) }
+        if fm.fileExists(atPath: spoolURL.path) { try fm.removeItem(at: spoolURL) }
+    }
+
+    public var statePath: String { stateURL.path }
+    public var spoolPath: String { spoolURL.path }
+
+    // MARK: - Internals
+
+    private func ensureDirectory() throws {
+        let dir = stateURL.deletingLastPathComponent()
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: dir.path) {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    }
+
+    private func readSpool() throws -> [DeviceAttributes] {
+        guard FileManager.default.fileExists(atPath: spoolURL.path) else { return [] }
+        let data = try Data(contentsOf: spoolURL)
+        guard !data.isEmpty else { return [] }
+        let decoder = JSONDecoder()
+        var devices: [DeviceAttributes] = []
+        // Each line is a self-contained JSON object. Split on newline and skip blanks so a
+        // truncated trailing write (process killed mid-line) is tolerated rather than fatal.
+        let text = String(decoding: data, as: UTF8.self)
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            guard let bytes = trimmed.data(using: .utf8) else { continue }
+            do {
+                let device = try decoder.decode(DeviceAttributes.self, from: bytes)
+                devices.append(device)
+            } catch {
+                // Skip a corrupt trailing line silently; on the next page write the file is rewritten.
+                continue
+            }
+        }
+        return devices
+    }
+
+    private func appendToSpool(_ devices: [DeviceAttributes]) throws {
+        let encoder = JSONEncoder()
+        var buffer = Data()
+        for device in devices {
+            let line = try encoder.encode(device)
+            buffer.append(line)
+            buffer.append(0x0A) // '\n'
+        }
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: spoolURL.path) {
+            try buffer.write(to: spoolURL, options: [.atomic])
+            try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: spoolURL.path)
+        } else {
+            let handle = try FileHandle(forWritingTo: spoolURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: buffer)
         }
     }
 
-    public var path: String { fileURL.path }
-
-    private static func fileURL(for profile: String) throws -> URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let safe = profile.replacingOccurrences(of: "/", with: "_")
-        return home
+    private static func fileURLs(for profile: String) throws -> (state: URL, spool: URL) {
+        let homePath = ProcessInfo.processInfo.environment["HOME"]
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let base = URL(fileURLWithPath: homePath, isDirectory: true)
             .appendingPathComponent(".config/asbmutil/state", isDirectory: true)
-            .appendingPathComponent("\(safe)-list-devices.json")
+        let safe = encodeProfile(profile)
+        return (
+            base.appendingPathComponent("\(safe)-list-devices.json"),
+            base.appendingPathComponent("\(safe)-list-devices.jsonl")
+        )
+    }
+
+    /// Reversible per-profile encoding. We percent-encode anything outside `[A-Za-z0-9._-]` so
+    /// `a/b` and `a_b` get distinct filenames and exotic characters can't collide or escape the
+    /// state directory. Falls back to the unencoded profile name only if encoding somehow fails.
+    private static func encodeProfile(_ profile: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "._-")
+        return profile.addingPercentEncoding(withAllowedCharacters: allowed) ?? profile
     }
 }

--- a/Sources/core/Utilities/ResumeStore.swift
+++ b/Sources/core/Utilities/ResumeStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Persistent snapshot of a paginated `list-devices` pull so a failed run can be resumed.
+public struct ListDevicesResumeState: Codable, Sendable {
+    public let profile: String
+    public let cursor: String?
+    public let devices: [DeviceAttributes]
+    public let devicesPerPage: Int?
+    public let totalLimit: Int?
+    public let pagesCompleted: Int
+    public let savedAt: Date
+
+    public init(
+        profile: String,
+        cursor: String?,
+        devices: [DeviceAttributes],
+        devicesPerPage: Int?,
+        totalLimit: Int?,
+        pagesCompleted: Int,
+        savedAt: Date = Date()
+    ) {
+        self.profile = profile
+        self.cursor = cursor
+        self.devices = devices
+        self.devicesPerPage = devicesPerPage
+        self.totalLimit = totalLimit
+        self.pagesCompleted = pagesCompleted
+        self.savedAt = savedAt
+    }
+}
+
+/// File-backed store for a single profile's `list-devices` resume state.
+///
+/// Layout: `~/.config/asbmutil/state/<profile>-list-devices.json`. The directory is created on
+/// first write. Reads return nil when the file is missing so `--resume` on a fresh run is a no-op
+/// rather than an error.
+public struct ResumeStore: Sendable {
+    public let profile: String
+    private let fileURL: URL
+
+    public init(profile: String) throws {
+        self.profile = profile
+        self.fileURL = try Self.fileURL(for: profile)
+    }
+
+    public func load() throws -> ListDevicesResumeState? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        let data = try Data(contentsOf: fileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ListDevicesResumeState.self, from: data)
+    }
+
+    public func save(_ state: ListDevicesResumeState) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(state)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+
+    public func clear() throws {
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+    }
+
+    public var path: String { fileURL.path }
+
+    private static func fileURL(for profile: String) throws -> URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let safe = profile.replacingOccurrences(of: "/", with: "_")
+        return home
+            .appendingPathComponent(".config/asbmutil/state", isDirectory: true)
+            .appendingPathComponent("\(safe)-list-devices.json")
+    }
+}


### PR DESCRIPTION
## Summary

Long `list-devices` pulls against ABM/ASM tenants with tens of thousands of devices can fail partway from a transient timeout or network blip. Today recovery means starting over from page 1. This PR adds a `--resume` flag that persists per-page state to disk so a failed pull can pick up where it left off.

A user managing a ~50K-device fleet reported pulls timing out around 30K — this is the first half of the fix (the second being a configurable per-request timeout, tracked separately).

## How it works

- `--resume` writes `{cursor, devices, devicesPerPage, totalLimit, pagesCompleted, savedAt}` to `~/.config/asbmutil/state/<profile>-list-devices.json` after each successful page.
- A subsequent `--resume` run reads that file, seeds the paginator with the saved cursor + devices, and continues until done.
- The state file is removed on successful completion so the next fresh run starts clean.
- State is per-profile so concurrent pulls against different tenants don't collide.

API surface: `APIClient.listDevices` gains an optional `ResumeHandle` (starting cursor + initial devices + per-page callback). The library is stateless; the CLI owns the file I/O.

## Test plan

- [ ] `asbmutil list-devices --resume` against a real tenant; let it complete and confirm the state file is removed.
- [ ] Same, but `Ctrl-C` partway through; re-run `--resume` and confirm it picks up at the saved page count.
- [ ] Confirm `--resume` with no prior state writes a "starting fresh" stderr line and behaves like a normal run.
- [ ] Verify resumed run preserves `--devices-per-page` warning when changed between runs.
- [ ] `--include-applecare` runs after `list-devices` completes (unchanged), so it still works when combined with `--resume`.