### PR TITLE
Verify serials exist before assign/unassign

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ For organizations managing multiple ABM instances, you can create named profiles
 # Assignment Operations
 ./asbmutil assign --serials P8R2K47NF5X9,Q7M5V83WH4L2 --mdm "Intune"
 ./asbmutil assign --csv-file devices.csv --mdm "Intune"
+./asbmutil assign --csv-file devices.csv --mdm "Intune" --skip-verify   # Submit as-is, no pre-flight 404 check
 ./asbmutil unassign --serials P8R2K47NF5X9,Q7M5V83WH4L2 --mdm "MicroMDM"
 ./asbmutil unassign --csv-file devices.csv --mdm "MicroMDM"
 
@@ -613,6 +614,20 @@ Both modes use efficient server-side device listing (4-5 API calls regardless of
   ]
 }
 ```
+
+### Pre-flight serial verification
+
+Apple's `orgDeviceActivities` endpoint accepts any serial you send it — including serials that aren't in your School/Business Manager account yet (e.g. a reseller issued a shipment notice but hasn't registered the device) or that are simply mistyped. The activity comes back `IN_PROGRESS` and `batch-status` later reports `COMPLETED`, even though nothing was assigned because the device never existed.
+
+To catch this, `assign` and `unassign` verify every serial against `GET /v1/orgDevices/{id}` before submitting. Serials that return HTTP 404 are reported on stderr and excluded; only confirmed devices are sent on for the activity. If none of the serials are valid, the command aborts without creating an activity.
+
+The verification adds one lightweight API call per serial (fanned out with bounded concurrency). To skip it and submit serials as-is — restoring the old behavior — pass `--skip-verify`:
+
+```bash
+./asbmutil assign --csv-file devices.csv --mdm "Intune" --skip-verify
+```
+
+The JSON activity result is still printed to stdout; verification diagnostics go to stderr, so piping to `jq` is unaffected.
 
 ## Network proxy
 

--- a/Sources/app/ViewModels/AssignmentViewModel.swift
+++ b/Sources/app/ViewModels/AssignmentViewModel.swift
@@ -18,6 +18,13 @@ final class AssignmentViewModel {
     var errorMessage: String?
     var servers: [MdmServerWithId] = []
 
+    /// Skip the pre-flight existence check and submit serials as-is.
+    var skipVerify = false
+    /// Serials Apple reported as not found (HTTP 404) during the last run — excluded from submission.
+    var notFoundSerials: [String] = []
+    /// Serials whose existence couldn't be determined during the last run — excluded from submission.
+    var erroredSerials: [String] = []
+
     var serialNumbers: [String] {
         if !importedSerials.isEmpty {
             return importedSerials
@@ -45,13 +52,34 @@ final class AssignmentViewModel {
         isExecuting = true
         errorMessage = nil
         result = nil
+        notFoundSerials = []
+        erroredSerials = []
 
         do {
             let serviceId = try await client.getMdmServerIdByName(selectedMdmName)
             let activityType = mode == .assign ? "ASSIGN_DEVICES" : "UNASSIGN_DEVICES"
+
+            // Pre-flight each serial unless the user opted out. Apple's activities endpoint
+            // reports success even for serials that don't exist (e.g. not yet registered by
+            // the reseller), so we filter those out and surface them for review.
+            let toSubmit: [String]
+            if skipVerify {
+                toSubmit = serialNumbers
+            } else {
+                let verification = await client.verifyDevices(serials: serialNumbers)
+                notFoundSerials = verification.notFound
+                erroredSerials = verification.errored.map { "\($0.serial): \($0.message)" }
+                guard !verification.found.isEmpty else {
+                    errorMessage = "No valid devices: all \(serialNumbers.count) serial(s) were not found or could not be verified."
+                    isExecuting = false
+                    return
+                }
+                toSubmit = verification.found
+            }
+
             result = try await client.createDeviceActivity(
                 activityType: activityType,
-                serials: serialNumbers,
+                serials: toSubmit,
                 serviceId: serviceId
             )
         } catch {
@@ -66,6 +94,8 @@ final class AssignmentViewModel {
         importedSerials.removeAll()
         result = nil
         errorMessage = nil
+        notFoundSerials = []
+        erroredSerials = []
     }
 
     func importCSV(from url: URL) {

--- a/Sources/app/Views/Assignments/AssignmentView.swift
+++ b/Sources/app/Views/Assignments/AssignmentView.swift
@@ -98,6 +98,13 @@ struct AssignmentView: View {
                 Text("\(viewModel.serialNumbers.count) serial(s)")
                     .foregroundStyle(.secondary).font(.caption)
             }
+
+            Toggle("Verify serials exist before submitting", isOn: Binding(
+                get: { !viewModel.skipVerify },
+                set: { viewModel.skipVerify = !$0 }
+            ))
+            .font(.caption)
+            .help("Checks each serial against School/Business Manager first. Serials that don't exist (e.g. not yet registered by the reseller) are reported and excluded rather than silently no-op'd.")
         }
     }
 
@@ -117,6 +124,30 @@ struct AssignmentView: View {
         if let error = viewModel.errorMessage {
             Label(error, systemImage: "exclamationmark.triangle")
                 .foregroundStyle(.red).font(.caption)
+        }
+
+        if !viewModel.notFoundSerials.isEmpty || !viewModel.erroredSerials.isEmpty {
+            GroupBox {
+                VStack(alignment: .leading, spacing: 6) {
+                    if !viewModel.notFoundSerials.isEmpty {
+                        Label("\(viewModel.notFoundSerials.count) serial(s) not found — excluded", systemImage: "questionmark.circle")
+                            .foregroundStyle(.orange).font(.caption.weight(.medium))
+                        Text(viewModel.notFoundSerials.joined(separator: ", "))
+                            .font(.caption.monospaced()).foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                        Text("Not registered in School/Business Manager yet, or mistyped.")
+                            .font(.caption2).foregroundStyle(.tertiary)
+                    }
+                    if !viewModel.erroredSerials.isEmpty {
+                        Label("\(viewModel.erroredSerials.count) serial(s) could not be verified — excluded", systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.orange).font(.caption.weight(.medium))
+                        Text(viewModel.erroredSerials.joined(separator: "\n"))
+                            .font(.caption.monospaced()).foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
 
         if let result = viewModel.result {

--- a/Sources/cli/Commands.swift
+++ b/Sources/cli/Commands.swift
@@ -128,6 +128,39 @@ struct ListDevices: AsyncParsableCommand {
     }
 }
 
+/// Pre-flight serials through `GET /v1/orgDevices/{id}` and return the ones safe to submit.
+///
+/// Apple's `orgDeviceActivities` endpoint accepts unknown serials and reports the activity as
+/// `COMPLETED` even when nothing happened, so a not-yet-registered or mistyped serial silently
+/// no-ops. This filters those out: not-found (HTTP 404) and unverifiable serials are reported to
+/// stderr and excluded, valid serials are returned. Throws if none survive. Diagnostics go to
+/// stderr so the JSON result on stdout stays machine-parseable.
+private func verifiedSerials(_ serials: [String], client: APIClient, operation: String) async throws -> [String] {
+    FileHandle.standardError.write(Data("Verifying \(serials.count) serial(s) exist before \(operation)...\n".utf8))
+    let result = await client.verifyDevices(serials: serials)
+
+    if !result.notFound.isEmpty {
+        FileHandle.standardError.write(Data("\nNot found (\(result.notFound.count)) — skipped:\n".utf8))
+        for s in result.notFound {
+            FileHandle.standardError.write(Data("  \(s)\n".utf8))
+        }
+        FileHandle.standardError.write(Data("These returned HTTP 404 — not yet registered by the reseller, or mistyped.\n".utf8))
+    }
+    if !result.errored.isEmpty {
+        FileHandle.standardError.write(Data("\nCould not verify (\(result.errored.count)) — skipped:\n".utf8))
+        for e in result.errored {
+            FileHandle.standardError.write(Data("  \(e.serial): \(e.message)\n".utf8))
+        }
+    }
+
+    guard !result.found.isEmpty else {
+        throw RuntimeError("No valid devices to \(operation): all \(serials.count) serial(s) were not found or could not be verified. Re-run with --skip-verify to submit anyway.")
+    }
+
+    FileHandle.standardError.write(Data("\nProceeding to \(operation) \(result.found.count) of \(serials.count) serial(s).\n".utf8))
+    return result.found
+}
+
 struct Assign: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "assign",
@@ -141,6 +174,9 @@ struct Assign: AsyncParsableCommand {
 
     @Option(name: .customLong("mdm"), help: "MDM server name")
     var mdmName: String
+
+    @Flag(name: .customLong("skip-verify"), help: "Skip the pre-flight check that each serial exists before submitting. By default, serials returning HTTP 404 (e.g. not yet registered by the reseller) are reported and excluded.")
+    var skipVerify: Bool = false
 
     @Option(name: .customLong("profile"), help: "Profile name to use for credentials")
     var profileName: String?
@@ -167,9 +203,13 @@ struct Assign: AsyncParsableCommand {
             throw ValidationError("No serial numbers provided")
         }
 
+        let toSubmit = skipVerify
+            ? serialNumbers
+            : try await verifiedSerials(serialNumbers, client: client, operation: "assign")
+
         let activityDetails = try await client.createDeviceActivity(
             activityType: "ASSIGN_DEVICES",
-            serials: serialNumbers,
+            serials: toSubmit,
             serviceId: serviceId
         )
         print(String(decoding: try JSONEncoder().encode(activityDetails), as: UTF8.self))
@@ -190,6 +230,9 @@ struct Unassign: AsyncParsableCommand {
     @Option(name: .customLong("mdm"), help: "MDM server name")
     var mdmName: String
 
+    @Flag(name: .customLong("skip-verify"), help: "Skip the pre-flight check that each serial exists before submitting. By default, serials returning HTTP 404 (e.g. not yet registered by the reseller) are reported and excluded.")
+    var skipVerify: Bool = false
+
     @Option(name: .customLong("profile"), help: "Profile name to use for credentials")
     var profileName: String?
 
@@ -215,9 +258,13 @@ struct Unassign: AsyncParsableCommand {
             throw ValidationError("No serial numbers provided")
         }
 
+        let toSubmit = skipVerify
+            ? serialNumbers
+            : try await verifiedSerials(serialNumbers, client: client, operation: "unassign")
+
         let activityDetails = try await client.createDeviceActivity(
             activityType: "UNASSIGN_DEVICES",
-            serials: serialNumbers,
+            serials: toSubmit,
             serviceId: serviceId
         )
         print(String(decoding: try JSONEncoder().encode(activityDetails), as: UTF8.self))

--- a/Sources/core/API/APIClient.swift
+++ b/Sources/core/API/APIClient.swift
@@ -265,7 +265,17 @@ public actor APIClient {
     public func verifyDevices(serials: [String], concurrency: Int = 4) async -> DeviceVerification {
         guard !serials.isEmpty else { return DeviceVerification(found: [], notFound: [], errored: []) }
         let cap = max(1, min(concurrency, 32))
-        let total = serials.count
+
+        // Probe each distinct serial once. Duplicates (from comma input or a CSV with repeats)
+        // would otherwise race in `resultBySerial` — two concurrent probes of the same serial
+        // could overwrite each other, leaving its bucket nondeterministic. We still walk the
+        // original `serials` for output so ordering and any intentional duplicates are preserved.
+        var uniqueSerials: [String] = []
+        var seen = Set<String>()
+        for serial in serials where seen.insert(serial).inserted {
+            uniqueSerials.append(serial)
+        }
+        let total = uniqueSerials.count
 
         enum Probe: Sendable {
             case found
@@ -290,14 +300,14 @@ public actor APIClient {
             }
 
             while index < cap && index < total {
-                enqueue(serials[index])
+                enqueue(uniqueSerials[index])
                 index += 1
             }
 
             while let (serial, probe) = await group.next() {
                 resultBySerial[serial] = probe
                 if index < total {
-                    enqueue(serials[index])
+                    enqueue(uniqueSerials[index])
                     index += 1
                 }
             }

--- a/Sources/core/API/APIClient.swift
+++ b/Sources/core/API/APIClient.swift
@@ -230,6 +230,93 @@ public actor APIClient {
         return out
     }
 
+    // MARK: - Pre-flight Device Verification
+
+    /// Check whether a single device exists in the org via `GET /v1/orgDevices/{serial}`.
+    ///
+    /// Returns `true` on HTTP 200 and `false` on HTTP 404. Any other status throws —
+    /// an ambiguous response (auth, server error after retries, etc.) must not be
+    /// silently treated as "not found", since that would drop a possibly-valid serial
+    /// from an assign/unassign batch.
+    public func deviceExists(serialNumber: String) async throws -> Bool {
+        try await ensureValidToken()
+
+        let url = URL(string: Endpoints.orgDevice(serialNumber).path, relativeTo: Endpoints.base(for: creds.scope))!
+        var urlReq = URLRequest(url: url)
+        urlReq.httpMethod = HTTPMethod.GET.rawValue
+        urlReq.setValue("Bearer \(token.access_token)", forHTTPHeaderField: "Authorization")
+        urlReq.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (_, http) = try await performRequestWithRetry(urlReq)
+        switch http.statusCode {
+        case 200: return true
+        case 404: return false
+        default: throw RuntimeError("HTTP error \(http.statusCode) while verifying device \(serialNumber)")
+        }
+    }
+
+    /// Pre-flight a batch of serials, splitting them into devices that exist in the org,
+    /// serials Apple reports as not found (HTTP 404), and serials whose status could not be
+    /// determined (anything else, after retries).
+    ///
+    /// Lookups fan out with bounded concurrency, matching `enrichWithAppleCare`: Apple's API
+    /// multiplexes over a single HTTP/2 connection per host and drops streams above ~4, so the
+    /// default cap is deliberately low. Input order is preserved in each output bucket.
+    public func verifyDevices(serials: [String], concurrency: Int = 4) async -> DeviceVerification {
+        guard !serials.isEmpty else { return DeviceVerification(found: [], notFound: [], errored: []) }
+        let cap = max(1, min(concurrency, 32))
+        let total = serials.count
+
+        enum Probe: Sendable {
+            case found
+            case notFound
+            case errored(String)
+        }
+
+        var resultBySerial: [String: Probe] = [:]
+
+        await withTaskGroup(of: (String, Probe).self) { group in
+            var index = 0
+
+            func enqueue(_ serial: String) {
+                group.addTask { [self] in
+                    do {
+                        let exists = try await self.deviceExists(serialNumber: serial)
+                        return (serial, exists ? .found : .notFound)
+                    } catch {
+                        return (serial, .errored(error.localizedDescription))
+                    }
+                }
+            }
+
+            while index < cap && index < total {
+                enqueue(serials[index])
+                index += 1
+            }
+
+            while let (serial, probe) = await group.next() {
+                resultBySerial[serial] = probe
+                if index < total {
+                    enqueue(serials[index])
+                    index += 1
+                }
+            }
+        }
+
+        var found: [String] = []
+        var notFound: [String] = []
+        var errored: [(serial: String, message: String)] = []
+        for serial in serials {
+            switch resultBySerial[serial] {
+            case .found: found.append(serial)
+            case .notFound: notFound.append(serial)
+            case .errored(let message): errored.append((serial, message))
+            case nil: errored.append((serial, "no result"))
+            }
+        }
+        return DeviceVerification(found: found, notFound: notFound, errored: errored)
+    }
+
     public func createDeviceActivity(activityType: String, serials: [String], serviceId: String) async throws -> ActivityDetails {
         struct ActivityResponse: Decodable {
             let data: ActivityData
@@ -712,11 +799,16 @@ public actor APIClient {
         }
     }
 
-    public func send<T: Decodable>(_ req: Request<T>) async throws -> T {
+    /// Refresh the access token if the cached one has expired.
+    private func ensureValidToken() async throws {
         if token.isExpired {
             token = try await Self.fetchToken(creds, session: session)
             Keychain.saveToken(token, profileName: profileName)
         }
+    }
+
+    public func send<T: Decodable>(_ req: Request<T>) async throws -> T {
+        try await ensureValidToken()
 
         let url: URL = req.path.hasPrefix("https://")
             ? URL(string: req.path)!
@@ -733,10 +825,30 @@ public actor APIClient {
             urlReq.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 
-        return try await performRequestWithRetry(urlReq)
+        let (data, http) = try await performRequestWithRetry(urlReq)
+
+        // Handle successful responses
+        if http.statusCode == 200 || http.statusCode == 201 {
+            return try JSONDecoder().decode(T.self, from: data)
+        }
+
+        // Non-retryable error - print diagnostic and throw
+        FileHandle.standardError.write(
+            Data("HTTP \(http.statusCode)\n".utf8)
+        )
+        FileHandle.standardError.write(data)
+        FileHandle.standardError.write(Data("\n".utf8))
+        throw RuntimeError("HTTP error \(http.statusCode)")
     }
 
-    private func performRequestWithRetry<T: Decodable>(_ urlReq: URLRequest) async throws -> T {
+    /// Execute a request with retry/backoff and return the final response.
+    ///
+    /// Retries 429/5xx/408 and transient network errors per the retry policy, then
+    /// returns the last `(data, response)` pair for any other status — including 4xx —
+    /// without throwing, so callers can branch on the status code (e.g. treat 404 as
+    /// "not found" rather than an error). Throws only on network failure or once
+    /// retries are exhausted.
+    private func performRequestWithRetry(_ urlReq: URLRequest) async throws -> (Data, HTTPURLResponse) {
         var lastError: Error?
 
         for attempt in 0...maxRetries {
@@ -744,11 +856,6 @@ public actor APIClient {
                 let (data, resp) = try await session.data(for: urlReq)
                 guard let http = resp as? HTTPURLResponse else {
                     throw RuntimeError("Invalid response type")
-                }
-
-                // Handle successful responses
-                if http.statusCode == 200 || http.statusCode == 201 {
-                    return try JSONDecoder().decode(T.self, from: data)
                 }
 
                 // Handle 429 (Rate Limited) and other retryable errors
@@ -763,13 +870,7 @@ public actor APIClient {
                     continue
                 }
 
-                // Non-retryable error - print diagnostic and throw
-                FileHandle.standardError.write(
-                    Data("HTTP \(http.statusCode)\n".utf8)
-                )
-                FileHandle.standardError.write(data)
-                FileHandle.standardError.write(Data("\n".utf8))
-                throw RuntimeError("HTTP error \(http.statusCode)")
+                return (data, http)
 
             } catch {
                 lastError = error

--- a/Sources/core/Models/Device.swift
+++ b/Sources/core/Models/Device.swift
@@ -286,6 +286,27 @@ public struct EnhancedAssignedServerData: Codable, Sendable {
     }
 }
 
+// MARK: - Device Verification (pre-flight existence check)
+
+/// Outcome of pre-flight `GET /v1/orgDevices/{id}` checks before an assign/unassign.
+///
+/// `found` are serials Apple confirmed exist in the org (HTTP 200) and are safe to submit.
+/// `notFound` are serials Apple reports don't exist (HTTP 404) — not yet registered by the
+/// reseller, or mistyped. `errored` are serials whose existence couldn't be determined
+/// (any other status after retries); they are excluded from submission and surfaced so the
+/// operator can retry rather than have a possibly-valid device silently dropped.
+public struct DeviceVerification: Sendable {
+    public let found: [String]
+    public let notFound: [String]
+    public let errored: [(serial: String, message: String)]
+
+    public init(found: [String], notFound: [String], errored: [(serial: String, message: String)]) {
+        self.found = found
+        self.notFound = notFound
+        self.errored = errored
+    }
+}
+
 // MARK: - Activity Details
 
 public struct ActivityDetails: Codable, Sendable, Identifiable {


### PR DESCRIPTION
Closes #22.

Apple's `orgDeviceActivities` endpoint accepts unknown serials and reports the activity as `COMPLETED` even when nothing happened, so a serial that isn't in School/Business Manager yet (e.g. not registered by the reseller) or is simply mistyped silently no-ops.

This pre-flights every serial through `GET /v1/orgDevices/{id}` before submitting:

- Serials returning 200 are passed through to the activity.
- 404s and unverifiable serials (auth/5xx after retries) are reported on stderr and excluded.
- If none are valid, the command aborts without creating an activity.
- `--skip-verify` opts out and submits as-is.

Lookups fan out with bounded concurrency (same pattern as the AppleCare enrichment). The activity JSON still goes to stdout and all diagnostics to stderr, so `| jq` pipelines are unaffected.

The macOS app's Assignment view gets a matching "Verify serials exist before submitting" toggle (on by default) and an inline panel listing not-found / unverifiable serials.