### PR TITLE
Confirm device assignment after submitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ For organizations managing multiple ABM instances, you can create named profiles
 ./asbmutil assign --serials P8R2K47NF5X9,Q7M5V83WH4L2 --mdm "Intune"
 ./asbmutil assign --csv-file devices.csv --mdm "Intune"
 ./asbmutil assign --csv-file devices.csv --mdm "Intune" --skip-verify   # Submit as-is, no pre-flight 404 check
+./asbmutil assign --serials P8R2K47NF5X9 --mdm "Intune" --confirm       # Poll to completion and verify it landed
 ./asbmutil unassign --serials P8R2K47NF5X9,Q7M5V83WH4L2 --mdm "MicroMDM"
 ./asbmutil unassign --csv-file devices.csv --mdm "MicroMDM"
 
@@ -628,6 +629,18 @@ The verification adds one lightweight API call per serial (fanned out with bound
 ```
 
 The JSON activity result is still printed to stdout; verification diagnostics go to stderr, so piping to `jq` is unaffected.
+
+### Post-assignment confirmation
+
+Pre-flight verification catches serials that don't exist before you submit, but the activity itself is still fire-and-forget — `IN_PROGRESS` followed by a `COMPLETED` batch status doesn't by itself prove each device landed on the intended MDM. Pass `--confirm` to close that loop:
+
+```bash
+./asbmutil assign --serials P8R2K47NF5X9 --mdm "Intune" --confirm
+```
+
+With `--confirm`, after submitting, `asbmutil` polls the activity until it reaches a terminal state, then re-queries each device's assigned server and reconciles it against the intended end state (on the target MDM for `assign`, off it for `unassign`). It reports how many devices reached the expected state and lists any that didn't, then exits non-zero if any device is unaccounted for — so a script can treat a partial assignment as a failure.
+
+Tune the polling with `--confirm-interval` (seconds between polls, default 10) and `--confirm-timeout` (max seconds to wait, default 240). As with verification, the activity JSON goes to stdout and all confirmation output goes to stderr.
 
 ## Network proxy
 

--- a/Sources/app/ViewModels/AssignmentViewModel.swift
+++ b/Sources/app/ViewModels/AssignmentViewModel.swift
@@ -25,6 +25,19 @@ final class AssignmentViewModel {
     /// Serials whose existence couldn't be determined during the last run — excluded from submission.
     var erroredSerials: [String] = []
 
+    /// After submitting, poll the activity and re-query each device to confirm the end state.
+    var confirmAfterSubmit = false
+    /// Whether a confirmation pass ran and produced results to show.
+    var didConfirm = false
+    /// Human-readable terminal status of the confirmed activity (e.g. COMPLETED, TIMEOUT).
+    var confirmStatus: String?
+    /// Count of devices confirmed in the expected end state.
+    var confirmedCount = 0
+    /// Serials that settled in a different state than intended.
+    var confirmMismatched: [String] = []
+    /// Serials whose final assignment couldn't be read.
+    var confirmErrored: [String] = []
+
     var serialNumbers: [String] {
         if !importedSerials.isEmpty {
             return importedSerials
@@ -54,6 +67,11 @@ final class AssignmentViewModel {
         result = nil
         notFoundSerials = []
         erroredSerials = []
+        didConfirm = false
+        confirmStatus = nil
+        confirmedCount = 0
+        confirmMismatched = []
+        confirmErrored = []
 
         do {
             let serviceId = try await client.getMdmServerIdByName(selectedMdmName)
@@ -77,11 +95,32 @@ final class AssignmentViewModel {
                 toSubmit = verification.found
             }
 
-            result = try await client.createDeviceActivity(
+            let activity = try await client.createDeviceActivity(
                 activityType: activityType,
                 serials: toSubmit,
                 serviceId: serviceId
             )
+            result = activity
+
+            // Optionally poll to completion and reconcile each device's actual end state.
+            if confirmAfterSubmit {
+                let status = try await client.waitForActivityTerminal(
+                    id: activity.id,
+                    intervalSeconds: 10,
+                    timeoutSeconds: 240
+                )
+                confirmStatus = status
+                if status != "TIMEOUT" {
+                    let expected: AssignmentExpectation = mode == .assign
+                        ? .assigned(serverId: serviceId)
+                        : .unassigned(serverId: serviceId)
+                    let reconciliation = await client.confirmAssignment(serials: toSubmit, expected: expected)
+                    confirmedCount = reconciliation.asExpected.count
+                    confirmMismatched = reconciliation.mismatched.map { "\($0.serial): now \($0.assignedTo.map { "on \($0)" } ?? "unassigned")" }
+                    confirmErrored = reconciliation.errored.map { "\($0.serial): \($0.message)" }
+                }
+                didConfirm = true
+            }
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -96,6 +135,11 @@ final class AssignmentViewModel {
         errorMessage = nil
         notFoundSerials = []
         erroredSerials = []
+        didConfirm = false
+        confirmStatus = nil
+        confirmedCount = 0
+        confirmMismatched = []
+        confirmErrored = []
     }
 
     func importCSV(from url: URL) {

--- a/Sources/app/Views/Assignments/AssignmentView.swift
+++ b/Sources/app/Views/Assignments/AssignmentView.swift
@@ -105,6 +105,10 @@ struct AssignmentView: View {
             ))
             .font(.caption)
             .help("Checks each serial against School/Business Manager first. Serials that don't exist (e.g. not yet registered by the reseller) are reported and excluded rather than silently no-op'd.")
+
+            Toggle("Confirm assignment after submitting", isOn: $viewModel.confirmAfterSubmit)
+                .font(.caption)
+                .help("After submitting, waits for the activity to finish and re-queries each device to confirm it actually reached the intended MDM. Slower, since it polls until the activity completes.")
         }
     }
 
@@ -162,6 +166,37 @@ struct AssignmentView: View {
                 }
                 LabeledContent("Status", value: result.status)
                 LabeledContent("Devices", value: "\(result.deviceCount)")
+            }
+        }
+
+        if viewModel.didConfirm {
+            GroupBox("Confirmation") {
+                VStack(alignment: .leading, spacing: 6) {
+                    if let status = viewModel.confirmStatus {
+                        LabeledContent("Activity", value: status)
+                    }
+                    if viewModel.confirmStatus == "TIMEOUT" {
+                        Label("Activity didn't finish in time — couldn't confirm end state.", systemImage: "clock.badge.exclamationmark")
+                            .foregroundStyle(.orange).font(.caption)
+                    } else {
+                        let total = viewModel.confirmedCount + viewModel.confirmMismatched.count + viewModel.confirmErrored.count
+                        Label("\(viewModel.confirmedCount)/\(total) device(s) confirmed in the expected state",
+                              systemImage: viewModel.confirmMismatched.isEmpty && viewModel.confirmErrored.isEmpty ? "checkmark.circle" : "exclamationmark.circle")
+                            .foregroundStyle(viewModel.confirmMismatched.isEmpty && viewModel.confirmErrored.isEmpty ? .green : .orange)
+                            .font(.caption.weight(.medium))
+                        if !viewModel.confirmMismatched.isEmpty {
+                            Text("Not in expected state:").font(.caption2).foregroundStyle(.secondary)
+                            Text(viewModel.confirmMismatched.joined(separator: "\n"))
+                                .font(.caption.monospaced()).foregroundStyle(.secondary).textSelection(.enabled)
+                        }
+                        if !viewModel.confirmErrored.isEmpty {
+                            Text("Could not confirm:").font(.caption2).foregroundStyle(.secondary)
+                            Text(viewModel.confirmErrored.joined(separator: "\n"))
+                                .font(.caption.monospaced()).foregroundStyle(.secondary).textSelection(.enabled)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/Sources/cli/Commands.swift
+++ b/Sources/cli/Commands.swift
@@ -241,6 +241,14 @@ struct Assign: AsyncParsableCommand {
         guard (serials != nil) != (csvFile != nil) else {
             throw ValidationError("Must specify either --serials or --csv-file, but not both")
         }
+        if confirm {
+            guard confirmInterval >= 1 else {
+                throw ValidationError("--confirm-interval must be at least 1 second")
+            }
+            guard confirmTimeout >= 1 else {
+                throw ValidationError("--confirm-timeout must be at least 1 second")
+            }
+        }
     }
 
     func run() async throws {
@@ -316,6 +324,14 @@ struct Unassign: AsyncParsableCommand {
         guard (serials != nil) != (csvFile != nil) else {
             throw ValidationError("Must specify either --serials or --csv-file, but not both")
         }
+        if confirm {
+            guard confirmInterval >= 1 else {
+                throw ValidationError("--confirm-interval must be at least 1 second")
+            }
+            guard confirmTimeout >= 1 else {
+                throw ValidationError("--confirm-timeout must be at least 1 second")
+            }
+        }
     }
 
     func run() async throws {
@@ -376,6 +392,17 @@ struct BatchStatus: AsyncParsableCommand {
 
     @Option(name: .customLong("profile"), help: "Profile name to use for credentials")
     var profileName: String?
+
+    func validate() throws {
+        if poll {
+            guard interval >= 1 else {
+                throw ValidationError("--interval must be at least 1 second")
+            }
+            guard timeout >= 1 else {
+                throw ValidationError("--timeout must be at least 1 second")
+            }
+        }
+    }
 
     func run() async throws {
         let client = try await APIClient(credentials: Creds.load(profileName: profileName), profileName: profileName)

--- a/Sources/cli/Commands.swift
+++ b/Sources/cli/Commands.swift
@@ -161,6 +161,53 @@ private func verifiedSerials(_ serials: [String], client: APIClient, operation: 
     return result.found
 }
 
+/// Poll the activity to a terminal state, then reconcile each serial's actual assignment against
+/// the intended end state. Reports to stderr (stdout is reserved for the activity JSON). Throws if
+/// any serial didn't land as expected, so callers exit non-zero — useful in scripts.
+private func confirmActivity(
+    _ activity: ActivityDetails,
+    serials: [String],
+    expected: AssignmentExpectation,
+    client: APIClient,
+    interval: Int,
+    timeout: Int
+) async throws {
+    FileHandle.standardError.write(Data("\nConfirming activity \(activity.id) (polling up to \(timeout)s)...\n".utf8))
+    let finalStatus = try await client.waitForActivityTerminal(
+        id: activity.id,
+        intervalSeconds: interval,
+        timeoutSeconds: timeout
+    ) { status in
+        FileHandle.standardError.write(Data("  poll: \(status)\n".utf8))
+    }
+
+    if finalStatus == "TIMEOUT" {
+        throw RuntimeError("Activity \(activity.id) did not reach a terminal state within \(timeout)s; cannot confirm. Re-check later with: asbmutil batch-status \(activity.id)")
+    }
+    FileHandle.standardError.write(Data("Activity terminal status: \(finalStatus)\n".utf8))
+
+    FileHandle.standardError.write(Data("Re-querying assignment for \(serials.count) device(s)...\n".utf8))
+    let result = await client.confirmAssignment(serials: serials, expected: expected)
+
+    FileHandle.standardError.write(Data("\nConfirmed as expected (\(result.asExpected.count)/\(serials.count)).\n".utf8))
+    if !result.mismatched.isEmpty {
+        FileHandle.standardError.write(Data("\nNot in expected state (\(result.mismatched.count)):\n".utf8))
+        for m in result.mismatched {
+            FileHandle.standardError.write(Data("  \(m.serial): now \(m.assignedTo.map { "on \($0)" } ?? "unassigned")\n".utf8))
+        }
+    }
+    if !result.errored.isEmpty {
+        FileHandle.standardError.write(Data("\nCould not confirm (\(result.errored.count)):\n".utf8))
+        for e in result.errored {
+            FileHandle.standardError.write(Data("  \(e.serial): \(e.message)\n".utf8))
+        }
+    }
+
+    if !result.mismatched.isEmpty || !result.errored.isEmpty {
+        throw RuntimeError("Confirmation incomplete: \(result.asExpected.count) of \(serials.count) device(s) reached the expected state.")
+    }
+}
+
 struct Assign: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "assign",
@@ -177,6 +224,15 @@ struct Assign: AsyncParsableCommand {
 
     @Flag(name: .customLong("skip-verify"), help: "Skip the pre-flight check that each serial exists before submitting. By default, serials returning HTTP 404 (e.g. not yet registered by the reseller) are reported and excluded.")
     var skipVerify: Bool = false
+
+    @Flag(name: .customLong("confirm"), help: "After submitting, poll the activity to completion and re-query each device to confirm it actually landed on the target MDM. Exits non-zero if any device didn't.")
+    var confirm: Bool = false
+
+    @Option(name: .customLong("confirm-interval"), help: "Seconds between confirmation polls (default: 10)")
+    var confirmInterval: Int = 10
+
+    @Option(name: .customLong("confirm-timeout"), help: "Max seconds to poll for completion when --confirm is set (default: 240)")
+    var confirmTimeout: Int = 240
 
     @Option(name: .customLong("profile"), help: "Profile name to use for credentials")
     var profileName: String?
@@ -213,6 +269,17 @@ struct Assign: AsyncParsableCommand {
             serviceId: serviceId
         )
         print(String(decoding: try JSONEncoder().encode(activityDetails), as: UTF8.self))
+
+        if confirm {
+            try await confirmActivity(
+                activityDetails,
+                serials: toSubmit,
+                expected: .assigned(serverId: serviceId),
+                client: client,
+                interval: confirmInterval,
+                timeout: confirmTimeout
+            )
+        }
     }
 }
 
@@ -232,6 +299,15 @@ struct Unassign: AsyncParsableCommand {
 
     @Flag(name: .customLong("skip-verify"), help: "Skip the pre-flight check that each serial exists before submitting. By default, serials returning HTTP 404 (e.g. not yet registered by the reseller) are reported and excluded.")
     var skipVerify: Bool = false
+
+    @Flag(name: .customLong("confirm"), help: "After submitting, poll the activity to completion and re-query each device to confirm it is no longer on the target MDM. Exits non-zero if any device still is.")
+    var confirm: Bool = false
+
+    @Option(name: .customLong("confirm-interval"), help: "Seconds between confirmation polls (default: 10)")
+    var confirmInterval: Int = 10
+
+    @Option(name: .customLong("confirm-timeout"), help: "Max seconds to poll for completion when --confirm is set (default: 240)")
+    var confirmTimeout: Int = 240
 
     @Option(name: .customLong("profile"), help: "Profile name to use for credentials")
     var profileName: String?
@@ -268,6 +344,17 @@ struct Unassign: AsyncParsableCommand {
             serviceId: serviceId
         )
         print(String(decoding: try JSONEncoder().encode(activityDetails), as: UTF8.self))
+
+        if confirm {
+            try await confirmActivity(
+                activityDetails,
+                serials: toSubmit,
+                expected: .unassigned(serverId: serviceId),
+                client: client,
+                interval: confirmInterval,
+                timeout: confirmTimeout
+            )
+        }
     }
 }
 
@@ -294,16 +381,12 @@ struct BatchStatus: AsyncParsableCommand {
         let client = try await APIClient(credentials: Creds.load(profileName: profileName), profileName: profileName)
 
         if poll {
-            let deadline = Date().addingTimeInterval(TimeInterval(timeout))
-            var finalStatus = "TIMEOUT"
-            while Date() < deadline {
-                let status = try await client.activityStatus(id: id)
+            let finalStatus = try await client.waitForActivityTerminal(
+                id: id,
+                intervalSeconds: interval,
+                timeoutSeconds: timeout
+            ) { status in
                 FileHandle.standardError.write(Data("poll: \(status)\n".utf8))
-                if status == "COMPLETE" || status == "COMPLETED" || status == "FAILED" || status == "ERROR" {
-                    finalStatus = status
-                    break
-                }
-                try await Task.sleep(nanoseconds: UInt64(interval) * 1_000_000_000)
             }
             print(finalStatus)
         } else {

--- a/Sources/core/API/APIClient.swift
+++ b/Sources/core/API/APIClient.swift
@@ -488,12 +488,21 @@ public actor APIClient {
     ///
     /// Returns the final status string, or `"TIMEOUT"` if the deadline passed before the
     /// activity settled. `onPoll` fires after each status read so callers can surface progress.
+    ///
+    /// Both `intervalSeconds` and `timeoutSeconds` must be positive: a zero interval would
+    /// busy-loop against the API and a negative one would trap on the `UInt64` sleep conversion.
     public func waitForActivityTerminal(
         id: String,
         intervalSeconds: Int,
         timeoutSeconds: Int,
         onPoll: (@Sendable (String) -> Void)? = nil
     ) async throws -> String {
+        guard intervalSeconds >= 1 else {
+            throw RuntimeError("Poll interval must be at least 1 second (got \(intervalSeconds)).")
+        }
+        guard timeoutSeconds >= 1 else {
+            throw RuntimeError("Poll timeout must be at least 1 second (got \(timeoutSeconds)).")
+        }
         let deadline = Date().addingTimeInterval(TimeInterval(timeoutSeconds))
         while Date() < deadline {
             let status = try await activityStatus(id: id)

--- a/Sources/core/API/APIClient.swift
+++ b/Sources/core/API/APIClient.swift
@@ -474,6 +474,112 @@ public actor APIClient {
         return response.data.attributes.status
     }
 
+    /// A device activity is in a terminal state once Apple stops processing it.
+    public static func isTerminalActivityStatus(_ status: String) -> Bool {
+        switch status.uppercased() {
+        case "COMPLETE", "COMPLETED", "FAILED", "ERROR", "STOPPED":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Poll an activity until it reaches a terminal state or the timeout elapses.
+    ///
+    /// Returns the final status string, or `"TIMEOUT"` if the deadline passed before the
+    /// activity settled. `onPoll` fires after each status read so callers can surface progress.
+    public func waitForActivityTerminal(
+        id: String,
+        intervalSeconds: Int,
+        timeoutSeconds: Int,
+        onPoll: (@Sendable (String) -> Void)? = nil
+    ) async throws -> String {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutSeconds))
+        while Date() < deadline {
+            let status = try await activityStatus(id: id)
+            onPoll?(status)
+            if Self.isTerminalActivityStatus(status) {
+                return status
+            }
+            try await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+        }
+        return "TIMEOUT"
+    }
+
+    /// Re-query each serial's assigned MDM server and reconcile it against the expected end state.
+    ///
+    /// `expected: .assigned(serverId)` confirms each device now reports that server; `.unassigned(serverId)`
+    /// confirms each device is no longer on that server (it may be unassigned or moved elsewhere). Serials
+    /// whose assignment can't be read (after retries) land in `errored` rather than being reported as a
+    /// mismatch. Lookups fan out with bounded concurrency; input order is preserved per bucket.
+    public func confirmAssignment(
+        serials: [String],
+        expected: AssignmentExpectation,
+        concurrency: Int = 4
+    ) async -> AssignmentReconciliation {
+        guard !serials.isEmpty else { return AssignmentReconciliation(asExpected: [], mismatched: [], errored: []) }
+        let cap = max(1, min(concurrency, 32))
+        let total = serials.count
+
+        enum Outcome: Sendable {
+            case assignedServer(String?)   // current server id, nil if unassigned
+            case errored(String)
+        }
+
+        var outcomeBySerial: [String: Outcome] = [:]
+
+        await withTaskGroup(of: (String, Outcome).self) { group in
+            var index = 0
+
+            func enqueue(_ serial: String) {
+                group.addTask { [self] in
+                    do {
+                        let response = try await self.getAssignedMdmRaw(deviceId: serial)
+                        return (serial, .assignedServer(response.data?.id))
+                    } catch {
+                        return (serial, .errored(error.localizedDescription))
+                    }
+                }
+            }
+
+            while index < cap && index < total {
+                enqueue(serials[index])
+                index += 1
+            }
+            while let (serial, outcome) = await group.next() {
+                outcomeBySerial[serial] = outcome
+                if index < total {
+                    enqueue(serials[index])
+                    index += 1
+                }
+            }
+        }
+
+        var asExpected: [String] = []
+        var mismatched: [(serial: String, assignedTo: String?)] = []
+        var errored: [(serial: String, message: String)] = []
+        for serial in serials {
+            switch outcomeBySerial[serial] {
+            case .assignedServer(let current):
+                let matches: Bool
+                switch expected {
+                case .assigned(let serverId): matches = (current == serverId)
+                case .unassigned(let serverId): matches = (current != serverId)
+                }
+                if matches {
+                    asExpected.append(serial)
+                } else {
+                    mismatched.append((serial, current))
+                }
+            case .errored(let message):
+                errored.append((serial, message))
+            case nil:
+                errored.append((serial, "no result"))
+            }
+        }
+        return AssignmentReconciliation(asExpected: asExpected, mismatched: mismatched, errored: errored)
+    }
+
     public func listMdmServers() async throws -> [MdmServerWithId] {
         let response: MdmServersResponse = try await send(
             Request(

--- a/Sources/core/Models/Device.swift
+++ b/Sources/core/Models/Device.swift
@@ -307,6 +307,33 @@ public struct DeviceVerification: Sendable {
     }
 }
 
+// MARK: - Post-assignment Confirmation
+
+/// The end state a confirmation check expects each serial to be in, carrying the target server id.
+public enum AssignmentExpectation: Sendable {
+    /// Device should now report this server as its assigned MDM (after an assign).
+    case assigned(serverId: String)
+    /// Device should no longer be on this server (after an unassign).
+    case unassigned(serverId: String)
+}
+
+/// Outcome of re-querying each serial's assigned MDM after an activity reached a terminal state.
+///
+/// `asExpected` are serials whose current assignment matches the intended end state. `mismatched`
+/// are serials that settled in a different state than intended (`assignedTo` is the server id they
+/// currently report, or nil if unassigned). `errored` are serials whose assignment couldn't be read.
+public struct AssignmentReconciliation: Sendable {
+    public let asExpected: [String]
+    public let mismatched: [(serial: String, assignedTo: String?)]
+    public let errored: [(serial: String, message: String)]
+
+    public init(asExpected: [String], mismatched: [(serial: String, assignedTo: String?)], errored: [(serial: String, message: String)]) {
+        self.asExpected = asExpected
+        self.mismatched = mismatched
+        self.errored = errored
+    }
+}
+
 // MARK: - Activity Details
 
 public struct ActivityDetails: Codable, Sendable, Identifiable {


### PR DESCRIPTION
Closes #23. Stacked on #24 (base is `verify-serials-before-assign`) — GitHub will retarget this to `main` once #24 merges.

Apple's `orgDeviceActivities` endpoint is fire-and-forget: a `COMPLETED` batch status doesn't prove each device actually landed on the intended MDM. This adds an opt-in `--confirm` flag to `assign`/`unassign` that:

- Polls the activity until it reaches a terminal state (or `--confirm-timeout`).
- Re-queries each device's assigned server and reconciles it against the intended end state — on the target MDM for `assign`, off it for `unassign`.
- Reports how many devices reached the expected state, lists any that didn't, and exits non-zero if any are unaccounted for, so a script can treat a partial result as failure.
- Tunable with `--confirm-interval` (default 10s) and `--confirm-timeout` (default 240s).

It's opt-in rather than default since, unlike pre-flight verification, it has to poll until the activity finishes.

Core additions: `waitForActivityTerminal` and `confirmAssignment`, plus `AssignmentExpectation` / `AssignmentReconciliation` models. `batch-status --poll` now shares the same polling primitive. The macOS app's Assignment view gets a matching "Confirm assignment after submitting" toggle and a results panel.