### PR TITLE
Align not-found message between CLI and GUI

### DIFF
--- a/Sources/app/Views/Assignments/AssignmentView.swift
+++ b/Sources/app/Views/Assignments/AssignmentView.swift
@@ -139,7 +139,7 @@ struct AssignmentView: View {
                         Text(viewModel.notFoundSerials.joined(separator: ", "))
                             .font(.caption.monospaced()).foregroundStyle(.secondary)
                             .textSelection(.enabled)
-                        Text("Not registered in School/Business Manager yet, or mistyped.")
+                        Text("Not in School/Business Manager yet (not registered by the reseller), or mistyped.")
                             .font(.caption2).foregroundStyle(.tertiary)
                     }
                     if !viewModel.erroredSerials.isEmpty {

--- a/Sources/cli/Commands.swift
+++ b/Sources/cli/Commands.swift
@@ -144,7 +144,7 @@ private func verifiedSerials(_ serials: [String], client: APIClient, operation: 
         for s in result.notFound {
             FileHandle.standardError.write(Data("  \(s)\n".utf8))
         }
-        FileHandle.standardError.write(Data("These returned HTTP 404 — not yet registered by the reseller, or mistyped.\n".utf8))
+        FileHandle.standardError.write(Data("These returned HTTP 404 — not in School/Business Manager yet (not registered by the reseller), or mistyped.\n".utf8))
     }
     if !result.errored.isEmpty {
         FileHandle.standardError.write(Data("\nCould not verify (\(result.errored.count)) — skipped:\n".utf8))


### PR DESCRIPTION
Follow-up to the v2026.06.07.2329 feedback from @saladd-bu: the pre-flight check explained a 404 differently depending on the surface — the CLI said "not yet registered by the reseller, or mistyped" while the GUI said "Not registered in School/Business Manager yet, or mistyped".

Both now use the same wording: **not in School/Business Manager yet (not registered by the reseller), or mistyped.** The help/tooltip text already matched, so this only touches the two result messages.

Wording-only; no behavior change.