### PR TITLE
Add Linux CI usage examples and GitHub Actions samples

### DIFF
--- a/examples/ci/README.md
+++ b/examples/ci/README.md
@@ -1,0 +1,82 @@
+# Running asbmutil in Linux CI
+
+`asbmutil` is a Swift binary, but the release build is a **static Linux
+executable** — so you can drive Apple Business/School Manager from any headless
+CI runner (GitHub Actions, Azure DevOps, GitLab) with no Mac and no Keychain in
+the loop. These samples show the whole pattern end to end.
+
+## The three-step pattern
+
+1. **Get the binary.** Download the latest `*-linux-amd64.tar.gz` asset from the
+   [releases](https://github.com/rodchristiansen/asbmutil/releases), untar, and
+   put `asbmutil` on `PATH`. It's self-contained (`--static-swift-stdlib`), so
+   there's nothing else to install.
+2. **Load credentials.** On Linux there's no Keychain, so `asbmutil` reads
+   credentials from a file store at `~/.config/asbmutil/`. `asbmutil config set`
+   writes that store from your ABM API client id, key id, and PEM private key —
+   supplied as CI secrets, never committed.
+3. **Run commands.** Every command prints clean JSON on stdout and all
+   diagnostics on stderr, so piping into `jq` (or a script) just works.
+
+[`setup-asbmutil.sh`](setup-asbmutil.sh) does steps 1 and 2 from three
+environment variables:
+
+```bash
+ASBM_CLIENT_ID=... ASBM_KEY_ID=... ASBM_PRIVATE_KEY_PEM="$(cat key.pem)" \
+  ./setup-asbmutil.sh
+```
+
+## Getting the credentials
+
+In Apple Business Manager, go to **Preferences → API**, create a managed API
+account, and download the private key (`.pem`). That gives you the client id,
+key id, and PEM. Store all three as secrets in your CI system:
+
+| Secret | Value |
+|---|---|
+| `ASBM_CLIENT_ID` | e.g. `BUSINESSAPI.84c7b9e1-...` |
+| `ASBM_KEY_ID` | the API key id |
+| `ASBM_PRIVATE_KEY_PEM` | the full contents of the `.pem` file |
+
+## GitHub Actions samples
+
+Copy either file into your repo's `.github/workflows/` (they live here, outside
+`.github/`, so they don't run against this repo):
+
+- **[`asbmutil-report.yml`](github-actions/asbmutil-report.yml)** — read-only.
+  On a daily schedule, pulls every MDM server and its device list and publishes
+  the JSON as a build artifact. A good "is ABM drifting from my inventory?"
+  heartbeat. Safe to run on a timer.
+- **[`asbmutil-assign.yml`](github-actions/asbmutil-assign.yml)** — write.
+  Manual-trigger reassignment of a set of serials to a target MDM server — the
+  core move of a MicroMDM → Intune migration. Dry-run by default: it always
+  shows the current assignment first, and only calls `assign --confirm` when you
+  uncheck the dry-run box.
+
+## Azure DevOps and others
+
+The same three steps work on any runner. In an Azure Pipelines job it's a
+`script:` step that curls the release asset and a second one that runs
+`asbmutil config set` from pipeline secrets — see
+[`setup-asbmutil.sh`](setup-asbmutil.sh) for the exact commands to lift.
+
+## Why the file store, and a gotcha
+
+On Linux (musl), `FileManager.homeDirectoryForCurrentUser` resolves the
+*passwd* home via `getpwuid()` and ignores `$HOME` — which bites service
+accounts whose passwd home is `/nonexistent`. The file store reads `$HOME`
+first for exactly this reason, so make sure your CI job has `HOME` set (GitHub
+and Azure runners do by default). If you provision the store by writing its JSON
+files directly instead of using `config set`, drop them in `$HOME/.config/asbmutil/`
+with `0600` permissions.
+
+## Handy read-only commands to script
+
+```bash
+asbmutil list-mdm-servers                          # every MDM server + id
+asbmutil list-devices-servers --all                # devices grouped by server
+asbmutil list-devices-servers --serials A,B,C      # which server each serial is on
+asbmutil get-devices-info --serials A,B,C          # attributes + AppleCare + MDM
+asbmutil list-devices --include-applecare          # whole-fleet AppleCare coverage
+asbmutil audit-events --start ... --end ... --type DEVICE_ASSIGNED_TO_SERVER
+```

--- a/examples/ci/README.md
+++ b/examples/ci/README.md
@@ -72,11 +72,28 @@ with `0600` permissions.
 
 ## Handy read-only commands to script
 
+Every MDM server and its id:
+
 ```bash
-asbmutil list-mdm-servers                          # every MDM server + id
-asbmutil list-devices-servers --all                # devices grouped by server
-asbmutil list-devices-servers --serials A,B,C      # which server each serial is on
-asbmutil get-devices-info --serials A,B,C          # attributes + AppleCare + MDM
-asbmutil list-devices --include-applecare          # whole-fleet AppleCare coverage
-asbmutil audit-events --start ... --end ... --type DEVICE_ASSIGNED_TO_SERVER
+asbmutil list-mdm-servers
+```
+
+Devices grouped by server, or the server a given set of serials is on:
+
+```bash
+asbmutil list-devices-servers --all
+asbmutil list-devices-servers --serials A,B,C
+```
+
+Full per-device attributes (including AppleCare and assigned MDM), and whole-fleet AppleCare coverage:
+
+```bash
+asbmutil get-devices-info --serials A,B,C
+asbmutil list-devices --include-applecare
+```
+
+Migration verification from Apple's own audit log (Business Manager only):
+
+```bash
+asbmutil audit-events --start 2026-07-01T00:00:00Z --end 2026-07-14T23:59:59Z --type DEVICE_ASSIGNED_TO_SERVER
 ```

--- a/examples/ci/github-actions/asbmutil-assign.yml
+++ b/examples/ci/github-actions/asbmutil-assign.yml
@@ -1,0 +1,54 @@
+name: Reassign devices to an MDM
+
+# Write example: move a set of serials to a different MDM server in ABM — the
+# core of a MicroMDM -> Intune (or any A -> B) migration. Manual-trigger only,
+# and dry-run by default so you always see the plan before anything changes.
+#
+# Secrets required: ASBM_CLIENT_ID, ASBM_KEY_ID, ASBM_PRIVATE_KEY_PEM.
+
+on:
+  workflow_dispatch:
+    inputs:
+      serials:
+        description: "Comma-separated serial numbers to reassign"
+        required: true
+      mdm:
+        description: "Target MDM server name (as it appears in ABM)"
+        required: true
+        default: "Intune"
+      dry_run:
+        description: "Show the plan without changing anything"
+        type: boolean
+        default: true
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install asbmutil + load credentials
+        env:
+          ASBM_CLIENT_ID: ${{ secrets.ASBM_CLIENT_ID }}
+          ASBM_KEY_ID: ${{ secrets.ASBM_KEY_ID }}
+          ASBM_PRIVATE_KEY_PEM: ${{ secrets.ASBM_PRIVATE_KEY_PEM }}
+        run: examples/ci/setup-asbmutil.sh
+
+      - name: Show current assignment
+        run: |
+          export PATH="$PWD/bin:$PATH"
+          echo "Current MDM for the requested serials:"
+          asbmutil list-devices-servers --serials "${{ inputs.serials }}" | jq
+
+      - name: Reassign
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          export PATH="$PWD/bin:$PATH"
+          asbmutil assign \
+            --serials "${{ inputs.serials }}" \
+            --mdm "${{ inputs.mdm }}" \
+            --confirm
+
+      - name: Dry run notice
+        if: ${{ inputs.dry_run == true }}
+        run: echo "Dry run — no changes made. Re-run with dry_run unchecked to apply."

--- a/examples/ci/github-actions/asbmutil-report.yml
+++ b/examples/ci/github-actions/asbmutil-report.yml
@@ -1,0 +1,41 @@
+name: ABM inventory report
+
+# Read-only example: pull the current device-to-MDM-server picture from Apple
+# Business/School Manager on a schedule and publish it as a build artifact.
+# Nothing here mutates ABM, so it's safe to run on a timer.
+#
+# Copy this file into your own repo's .github/workflows/ and add three secrets:
+#   ASBM_CLIENT_ID, ASBM_KEY_ID, ASBM_PRIVATE_KEY_PEM
+# (Create the API credential in ABM → Preferences → API, then download the key.)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *"   # every day at 07:00 UTC
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install asbmutil + load credentials
+        env:
+          ASBM_CLIENT_ID: ${{ secrets.ASBM_CLIENT_ID }}
+          ASBM_KEY_ID: ${{ secrets.ASBM_KEY_ID }}
+          ASBM_PRIVATE_KEY_PEM: ${{ secrets.ASBM_PRIVATE_KEY_PEM }}
+        run: examples/ci/setup-asbmutil.sh
+
+      - name: Pull ABM state
+        run: |
+          export PATH="$PWD/bin:$PATH"
+          mkdir -p out
+          asbmutil list-mdm-servers > out/mdm-servers.json
+          asbmutil list-devices-servers --all > out/devices-by-server.json
+          echo "Servers:"
+          jq -r '.[] | "  \(.serverName): \(.deviceCount // "n/a") devices"' out/devices-by-server.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: abm-report
+          path: out/*.json

--- a/examples/ci/setup-asbmutil.sh
+++ b/examples/ci/setup-asbmutil.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Download the latest Linux asbmutil release and load API credentials from the
+# environment, so a headless CI job (GitHub Actions, Azure DevOps, GitLab, …)
+# can talk to Apple Business/School Manager with no Mac and no Keychain.
+#
+# The static Linux binary reads credentials from ~/.config/asbmutil/ (a file
+# store, since there's no Keychain on Linux). `asbmutil config set` writes that
+# store for us, so all this script needs from the environment is:
+#
+#   ASBM_CLIENT_ID        e.g. BUSINESSAPI.84c7b9e1-...
+#   ASBM_KEY_ID           the API key id
+#   ASBM_PRIVATE_KEY_PEM  the PEM private key, contents (not a path)
+#
+# After sourcing/running this, `asbmutil` is on PATH via ./bin and ready to use.
+#
+# Usage:
+#   ASBM_CLIENT_ID=... ASBM_KEY_ID=... ASBM_PRIVATE_KEY_PEM="$(cat key.pem)" \
+#     ./setup-asbmutil.sh
+set -euo pipefail
+
+REPO="rodchristiansen/asbmutil"
+BIN_DIR="${BIN_DIR:-$PWD/bin}"
+
+# 1. Fetch the latest Linux release asset and unpack it.
+mkdir -p "$BIN_DIR"
+asset_url=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | python3 -c "import sys,json; a=json.load(sys.stdin)['assets']; print(next(x['browser_download_url'] for x in a if 'linux' in x['name']))")
+echo "Downloading asbmutil: $asset_url"
+curl -fsSL -o /tmp/asbmutil.tar.gz "$asset_url"
+tar xzf /tmp/asbmutil.tar.gz -C "$BIN_DIR"
+chmod +x "$BIN_DIR/asbmutil"
+rm -f /tmp/asbmutil.tar.gz
+export PATH="$BIN_DIR:$PATH"
+
+# 2. Load credentials into the file store via `config set`.
+: "${ASBM_CLIENT_ID:?set ASBM_CLIENT_ID}"
+: "${ASBM_KEY_ID:?set ASBM_KEY_ID}"
+: "${ASBM_PRIVATE_KEY_PEM:?set ASBM_PRIVATE_KEY_PEM}"
+
+pem_file=$(mktemp)
+trap 'rm -f "$pem_file"' EXIT
+printf '%s' "$ASBM_PRIVATE_KEY_PEM" > "$pem_file"
+
+asbmutil config set \
+  --client-id "$ASBM_CLIENT_ID" \
+  --key-id "$ASBM_KEY_ID" \
+  --pem-path "$pem_file"
+
+echo "asbmutil ready: $(asbmutil --version 2>/dev/null || echo installed)"


### PR DESCRIPTION
Adds an `examples/ci/` directory showing how to run the static Linux `asbmutil` binary in a headless CI job — no Mac, no Keychain.

## What's here

- **`setup-asbmutil.sh`** — reusable: downloads the latest `*-linux-amd64` release asset, then loads credentials into the Linux file store via `config set` from three env vars (`ASBM_CLIENT_ID`, `ASBM_KEY_ID`, `ASBM_PRIVATE_KEY_PEM`).
- **`github-actions/asbmutil-report.yml`** — read-only, scheduled. Pulls MDM servers + device lists and uploads the JSON as an artifact. Safe to run on a timer.
- **`github-actions/asbmutil-assign.yml`** — write, manual-trigger, dry-run by default. Reassigns serials to a target MDM server (the core of a MicroMDM → Intune migration), showing current assignment first and only calling `assign --confirm` when dry-run is unchecked.
- **`README.md`** — the three-step pattern (get binary → load creds → run), how to create the ABM API credential, the Azure DevOps equivalent, and the musl `$HOME`/`getpwuid()` gotcha.

Samples live under `examples/` (not `.github/workflows/`) so they don't execute against this repo — users copy them into their own repo.

A companion blog post walks through the same pattern.